### PR TITLE
Include acmart-options to allow for more detailed configuration

### DIFF
--- a/_extensions/quarto-journals/acm/acmarttemplate.tex
+++ b/_extensions/quarto-journals/acm/acmarttemplate.tex
@@ -1,4 +1,4 @@
-\documentclass[manuscript,screen$if(acm-metadata.final)$$else$,review$endif$$if(acm-metadata.anonymous)$,anonymous$endif$]{acmart}
+\documentclass[$if(acm-metadata.acmart-options)$$acm-metadata.acmart-options$$else$manuscript,screen$if(acm-metadata.final)$$else$,review$endif$$if(acm-metadata.anonymous)$,anonymous$endif$$endif$]{acmart}
 
 $-- % Options for packages loaded elsewhere
 $-- \PassOptionsToPackage{unicode$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref}

--- a/template.qmd
+++ b/template.qmd
@@ -81,6 +81,9 @@ acm-metadata:
 
   # comment this out to build a final version
   final: true
+  
+  # comment this out to specify detailed document options
+  # acmart-options: sigconf, review
 
   # acm preamble information
   copyright-year: 2018


### PR DESCRIPTION
Adds acmart-options as suggested here:

https://github.com/quarto-journals/acm/issues/11#issuecomment-1380729545

This allows the author to configure the article options, for example to switch from the manuscript to sigconf layout or add/remove line numbers.

This also adds a comment in the quarto template with an example to use the options