### PR TITLE
teaser figure - fix to acmarttemplate.tex and template.qmd

### DIFF
--- a/_extensions/quarto-journals/acm/acmarttemplate.tex
+++ b/_extensions/quarto-journals/acm/acmarttemplate.tex
@@ -394,13 +394,11 @@ $if(acm-metadata.keywords)$
 $endif$
 
 $if(acm-metadata.teaser)$
-\begin{verbatim}
-  \begin{teaserfigure}
-    \includegraphics[width=\textwidth]{$acm-metadata.teaser.image$}
-    \caption{$acm-metadata.teaser.caption$}
-    \Description{$acm-metadata.teaser.description$}
-  \end{teaserfigure}
-\end{verbatim}
+\begin{teaserfigure}
+  \includegraphics[width=\textwidth]{$acm-metadata.teaser.image$}
+  \caption{$acm-metadata.teaser.caption$}
+  \Description{$acm-metadata.teaser.description$}
+\end{teaserfigure}
 $endif$
 
 %%

--- a/template.qmd
+++ b/template.qmd
@@ -144,7 +144,7 @@ acm-metadata:
   # if uncommented, this produces a teaser figure
   # 
   # teaser:
-  #   image: sampleteaser
+  #   image: sample-franklin.png
   #   caption: figure caption
   #   description: teaser description    
 


### PR DESCRIPTION
When uncommented, the part of the template.qmd that should render the teaser figure did not work. To fix this, I have removed the \begin and \end{verbatim} command from acmart.tex that is meant to process the teaser figure part of the yaml from the .qmd. I have also corrected where the teaser figure points (sampleteaser --> sample-franklin.png) so that it renders the teaser.